### PR TITLE
Change deprecated to warning tag in flavors so it actually looks like a warning

### DIFF
--- a/source/Flavors.rst
+++ b/source/Flavors.rst
@@ -9,14 +9,14 @@ Note: our flavors are created in so that they will efficiently pack onto the har
 ################################
 m*.* (e.g. m1.small or m3.large)
 ################################
-.. deprecated:: 26/08/2020
+.. Warning:: Deprecated
 
-    These are over committed flavors meaning that any VCPU core assigned to your VM may be shared with up to 3 other VMs.
-
-    This means that these VMs can be great for light workloads such as interactive testing or hosting web services but are not generally suitable for hosting services or doing intensive work.
-    
     Please use c* flavors instead
 
+These are over committed flavors meaning that any VCPU core assigned to your VM may be shared with up to 3 other VMs.
+
+This means that these VMs can be great for light workloads such as interactive testing or hosting web services but are not generally suitable for hosting services or doing intensive work.
+    
 
 ################################
 c*.* (e.g. c1.small or c3.large)

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,9 +18,9 @@
 
 
 # -- Project information -----------------------------------------------------
-
+import datetime
 project = 'stfc-cloud-docs'
-copyright = '2018, CloudTeam'
+copyright = f'{str(datetime.date.today().year)}, CloudTeam'
 author = 'CloudTeam'
 
 # The short X.Y version


### PR DESCRIPTION
Changes deprecated to warning, whilst Sphinx correctly emits
class=deprecated for the `<p>` tag in the HTML, read the docs does not
have CSS for it *sigh*. 

So instead use a warning tag (which it does have) for a
nice big shiny box.

This also includes a tweak for the copyright to automatically update
each year when we push updates, as it was previously 2018

Here is a preview of a nice big obvious user-friendly box:
![image](https://user-images.githubusercontent.com/1817032/106786672-b6781900-6646-11eb-86ff-478bd7db56c8.png)
