### PR TITLE
Make all flavors spelling the same to help searching

### DIFF
--- a/source/faqs.rst
+++ b/source/faqs.rst
@@ -212,7 +212,7 @@ What are the current machine "flavors"? Can I have  a machine that looks like a 
 For most people the pre-configured flavors should fit almost every workload.
 See :ref:`flavors` for the types available. 
 
-Please contact us if you need assistance creating your own local project flavours.
+Please contact us if you need assistance creating your own local project flavors.
 
 ###################################################
 Can you provide operating system "X" on Openstack?

--- a/source/howto/CreateVMFromCommandLine.rst
+++ b/source/howto/CreateVMFromCommandLine.rst
@@ -39,7 +39,7 @@ It is common to put all of the above in a shell file (just as above, but with a 
 ####################################
 Finding images and flavors available
 ####################################
-Once on the command line of a server, you need to list the flavours available for the project to use as well as the images available.
+Once on the command line of a server, you need to list the flavors available for the project to use as well as the images available.
 To see the images available, run:-
 
 .. code-block:: bash
@@ -131,7 +131,7 @@ Here is an example command, putting together information from the previous comma
 
   openstack server create --flavor m1.tiny --image ScientificLinux-7-NoGui --nic net-id=Internal --security-group default --key-name xbe91637 test_2018-10-29_1511
 
-…where flavour and image are from the previous commands used, net_id is the name of the Network to be used (note you can use the actual Net_ID number instead if preferred – it can make things faster!). Security group is defining the specific security group, and key-name, chooses the ssh keypair to include when creating the host. “test_2018-10-29_1511” is the name of the host that is being created – known within openstack.
+…where flavor and image are from the previous commands used, net_id is the name of the Network to be used (note you can use the actual Net_ID number instead if preferred – it can make things faster!). Security group is defining the specific security group, and key-name, chooses the ssh keypair to include when creating the host. “test_2018-10-29_1511” is the name of the host that is being created – known within openstack.
 Some useful extras
 Adding --timing after the openstack command provides some statistics of how quickly various calls are being completed. You will see the usual host creation data, but at the end, you will also see the response times of each openstack API module.
 

--- a/source/howto/GrowTheDiskOfAVolumeVM.rst
+++ b/source/howto/GrowTheDiskOfAVolumeVM.rst
@@ -7,7 +7,7 @@ Scenario
 ##########
 In the STFC cloud, if you created a new VM in instances, the default setting in the “Sources” was to create the VM with a new volume.
 If you run out of disk space on the VM, you can usually just “resize” it to a new Flavor, and you will have the same VM, but with more space.
-However, with Volumes, the system ignores the disk sizing aspect of the flavour. This document describes how to create a clone of the original VM and increase the disk size, so that space is available on the new VM.
+However, with Volumes, the system ignores the disk sizing aspect of the flavor. This document describes how to create a clone of the original VM and increase the disk size, so that space is available on the new VM.
 
 ###########
 Method
@@ -32,7 +32,7 @@ Click on the Compute, then Instances menu on the LHS, Click on the “Launch Ins
 Fill in the Details section as normal.
 Click on Source: Select “Volume” in the “Select Boot source” – the volume that was created in the previous step should be visible – select this volume:-
 
-Select a flavour on the LHS: Note that the disk size of the flavour has no effect on the volume.
+Select a flavor on the LHS: Note that the disk size of the flavor has no effect on the volume.
 Select Networks and choose the network you wish to have the VM start up on.
 At this point, all of the LHS options should not have any asterisk (*) characters next to them, which means all the mandatory data has been filled in. You can then click on the “Launch instance” option.
 The system should boot up and appear in the list of Instances, and when you log into it, it should show the full disk size of the new volume:-
@@ -40,6 +40,6 @@ The system should boot up and appear in the list of Instances, and when you log 
 Logging into the new host, you can see the disk space now available:-
 
 Things worthy of note when creating a VM from an existing volume
-The flavour of the new VM does not affect the disk size – only the volume parameters does this !
+The flavor of the new VM does not affect the disk size – only the volume parameters does this !
 Once the volume is attached to a VM, you cannot remove it: the only way to remove the VM host from the volume is if the instance is created, and when the VM was created, the setting for the volume to persist still exists. (See document “Useful command line notes” in the TWKI, which describes a “cinder force-delete <volume id>” workflow.
 When creating a new instance from a volume, the volume may still have previous users created in the system and their home directories and they may have their details still in the /etc/sudoers.d/cloud file. However, you will not find that your FEDID has been added to the /etc/sudoers.d/cloud file.


### PR DESCRIPTION
This is very small PR to make all "flavour" spelling to be flavor, this is done to help search to detect all "flavor" references and be less confusing.