### PR TITLE
Add missing step to clusterctl init for KinD cluster

### DIFF
--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -143,6 +143,12 @@ Configuring the cluster
 
     export CLUSTER_NAME=demo
 
+- Initialise clusterctl on the KinD bootstrap cluster
+
+.. code-block:: bash
+
+    clusterctl init --infrastructure openstack
+
 - Generate the cluster config:
 
 .. code-block:: bash


### PR DESCRIPTION
Adds a missing step to initialise clusterctl on the KinD cluster, as we only had the steps for the created dest cluster