### PR TITLE
Add details on our K8s image

### DIFF
--- a/source/ClusterAPI/Introduction.rst
+++ b/source/ClusterAPI/Introduction.rst
@@ -10,3 +10,9 @@ This provides a nuber of advantages including:
 - Tooling which directly supports Openstack, including resource creation and management.
 - Support and fixes for newer Kuberenetes versions without waiting for Openstack upgrades.
 
+The Kubernetes image provided is based on 
+`upstream's Ubuntu image <https://github.com/kubernetes-sigs/image-builder/tree/master/images/capi>`_,
+which has been forked to comply with UKRI security policy `here <https://github.com/stfc/k8s-image-builder>`_.
+
+Unlike Magnum, the Kubernetes version supported is completely decoupled from Openstack, with upstream
+typically supporting the N-1 major version (where N is the latest release).


### PR DESCRIPTION
Adds notes about where our K8s image is built from, and explicitly call out the versioning is different to Magnum based on in-person user concerns.