### PR TITLE
Fix the title from the repo title

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to stfc-cloud-docs's documentation!
+Welcome to the STFC Cloud documentation!
 ===========================================
 
 .. comment Depth == 1 to get people to navigate to sub-page so we don't overfill contents bar


### PR DESCRIPTION
Fixes the title instead of showing the generic repo name on our landing page