### PR TITLE
Make it clear which Ubuntu image we need for mgmt machine

### DIFF
--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -49,7 +49,10 @@ recommended to use this cluster for any production workloads.
 Bootstrap Machine Prep
 ----------------------
 
-A Ubuntu machine is used to provide the KinD cluster. The following packages are required and 
+A Ubuntu machine is used to provide the KinD cluster. This should use the normal
+cloud Ubuntu image, not the stripped down CAPI image designed for nodes.
+
+The following packages are required and
 can be installed and configured using the following commands:
 
 .. code-block:: bash


### PR DESCRIPTION
This is based on user feedback, as they weren't sure if they were using the CAPI image or not.