### PR TITLE
Add documentation with using StackHPC helm chart instead

### DIFF
--- a/source/ClusterAPI/Introduction.rst
+++ b/source/ClusterAPI/Introduction.rst
@@ -6,6 +6,7 @@ Cluster API is a platform agnostic way of managing physical resources (i.e. VMs)
 Kubernetes.
 
 This provides a nuber of advantages including:
+
 - Familiarity to experience K8s admins, as nodes act similarly to pods...etc.
 - Tooling which directly supports Openstack, including resource creation and management.
 - Support and fixes for newer Kuberenetes versions without waiting for Openstack upgrades.

--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -54,7 +54,8 @@ can be installed and configured using the following commands:
     sudo apt install -y docker.io
     sudo usermod -aG docker $USER
 
-- You will need to exit and login again if you have installed docker to pick up the new group membership
+- You will need to exit and login again if you have added yourself to the docker group (usermod).
+  This is to pick up the new group membership
 - Snap is used to install kubectl, go (for KinD) and Helm
 
 .. code-block:: bash
@@ -64,11 +65,12 @@ can be installed and configured using the following commands:
     for i in kubectl go helm; do sudo snap install $i --classic; done
 
 - Go modules can be permanently added to the path by appending the following to the user's .bashrc file:
-  Then `source ~/.bashrc` or logout and login again.
 
 .. code-block:: bash
 
-    export PATH="/home/$USER/go/bin:$PATH"
+    echo "/home/$USER/go/bin:$PATH" >> ~/.bashrc
+
+- Then `source ~/.bashrc` or logout and login again.
 
 - Start the KinD cluster to bootstrap the main cluster
 
@@ -89,7 +91,16 @@ can be installed and configured using the following commands:
     sudo mv ./clusterctl /usr/local/bin/clusterctl
     clusterctl init --infrastructure openstack
 
-These steps only have to be completed once per management machine.
+If you run into GitHub rate limiting you will have to generate a personal API token as described
+`here. <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+This only requires the Repo scope, and is set on the CLI as follows
+
+.. code-block:: bash
+
+    export GITHUB_TOKEN=<your token>
+
+
+These setup steps only have to be completed once per management machine.
 
 Openstack Preparation
 ---------------------
@@ -126,11 +137,11 @@ Your clouds.yaml should now look like:
 
     clouds:
         openstack:
-            auth:
-            auth_url: https://openstack.stfc.ac.uk:5000/v3
-            application_credential_id: ""
-            application_credential_secret: ""
-            project_id: ""
+          auth:
+          auth_url: https://openstack.stfc.ac.uk:5000/v3
+          application_credential_id: ""
+          application_credential_secret: ""
+          project_id: ""
         region_name: "RegionOne"
         interface: "public"
         identity_api_version: 3
@@ -148,7 +159,7 @@ The configuration is spread across multiple yaml files to make it easier to mana
 These are as follows:
 
 - `values.yaml` contains the default values for the cluster using the STFC Cloud service. These should not be changed.
-- `user-values.yaml` contains some values that must be set by the user. There are also optional values that can be changed too for advanced users.
+- **`user-values.yaml` contains some values that must be set by the user.** There are also optional values that can be changed too for advanced users.
 - `flavors.yaml` contains the Openstack flavors to use for worker nodes. Common flavors are provided and can be uncommented and changed as required.
    By default the cluster will use l3.nano workers by default if unspecified.
 - `clouds.yaml` contains the Openstack application credentials. This file should be in the same directory as the other yaml files.
@@ -177,7 +188,7 @@ Configuring the cluster
 
     # Deploy the cluster called "demo-cluster"
     helm repo add capi https://stackhpc.github.io/capi-helm-charts
-    helm upgrade $CLUSTER_NAME capi/openstack-cluster --install -f values.yaml -f clouds.yaml -f user-values.yaml -f flavors.yaml
+    helm upgrade $CLUSTER_NAME capi/openstack-cluster --install -f values.yaml -f clouds.yaml -f user-values.yaml -f flavors.yaml --wait
 
 - Progress can be monitored with the following command in a separate terminal:
 

--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -34,13 +34,13 @@ Background
 ----------
 
 A Kubernetes cluster is required to create the cluster. To break this "chicken-egg" problem
-a Kubernetes-in-Docker (KinD) cluster is created to bootstrap the main cluster. It is not
+a minikube cluster is created to bootstrap the main cluster. It is not
 recommended to use this cluster for any production workloads.
 
 Bootstrap Machine Prep
 ----------------------
 
-A Ubuntu machine is used to provide the KinD cluster. This should use the normal
+A Ubuntu machine is used to provide the minikube cluster. This should use the normal
 cloud Ubuntu image, not the stripped down CAPI image designed for nodes.
 
 The following packages are required and
@@ -56,30 +56,25 @@ can be installed and configured using the following commands:
 
 - You will need to exit and login again if you have added yourself to the docker group (usermod).
   This is to pick up the new group membership
-- Snap is used to install kubectl, go (for KinD) and Helm
+- Snap is used to install kubectl and Helm
 
 .. code-block:: bash
 
     sudo apt-get update && sudo apt-get install -y snapd
     export PATH=$PATH:/snap/bin
-    for i in kubectl go helm; do sudo snap install $i --classic; done
+    sudo snap install kubectl --classic
+    sudo snap install helm --classic
 
-- Go modules can be permanently added to the path by appending the following to the user's .bashrc file:
-
-.. code-block:: bash
-
-    echo "/home/$USER/go/bin:$PATH" >> ~/.bashrc
-
-- Then `source ~/.bashrc` or logout and login again.
-
-- Start the KinD cluster to bootstrap the main cluster
+- Install minikube and start a cluster:
 
 .. code-block:: bash
 
-    go install sigs.k8s.io/kind@v0.14.0
-    kind create cluster
+    wget https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+    chmod +x minikube-linux-amd64
+    sudo mv minikube-linux-amd64 /usr/local/bin/minikube
+    minikube start --driver=docker
 
-- Install clusterctl and the Openstack provider into your KinD cluster:
+- Install clusterctl and the Openstack provider into your minikube cluster:
 
 .. code-block:: bash
 
@@ -208,7 +203,7 @@ Configuring the cluster
 Moving the control plane
 ========================
 
-At this point the control plane is still on the KinD cluster. This is not recommended for
+At this point the control plane is still on the minikube cluster. This is not recommended for
 long-lived or production workloads. We can pivot the cluster to self-manage:
 
 .. warning::
@@ -216,8 +211,8 @@ long-lived or production workloads. We can pivot the cluster to self-manage:
     After moving the control plane the kubeconfig cannot be retrieved if lost.
     Ensure a copy of the kubeconfig is placed into secure storage for production clusters.
 
-Moving from KinD cluster
-------------------------
+Moving from minikube cluster
+----------------------------
 
 - Install clusterctl into the new cluster and move the control plane
 
@@ -233,10 +228,10 @@ Moving from KinD cluster
 
     kubectl get kubeadmcontrolplane --kubeconfig=kubeconfig.$CLUSTER_NAME
 
-KinD Shutdown
--------------
+minikube Shutdown
+-----------------
 
-- Replace the existing KinD kubeconfig with the new cluster's kubeconfig
+- Replace the existing minikube kubeconfig with the new cluster's kubeconfig
 
 .. code-block:: bash
 
@@ -247,10 +242,10 @@ KinD Shutdown
     # Update the cluster to ensure everything lines up with your helm chart
     helm upgrade $CLUSTER_NAME capi/openstack-cluster --install -f values.yaml -f clouds.yaml -f user-values.yaml -f flavors.yaml
 
-- Remove KinD bootstrap cluster
+- Remove minikube bootstrap cluster
 
 .. code-block:: bash
 
-    kind delete cluster
+    minikube delete
 
 Your cluster is now complete

--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -23,8 +23,9 @@ to quickly gain access and perform recovery or upgrades as required.
 Account Security
 ----------------
 
-A `clouds.yaml` file with the application credentials is also required. This file should be removed or restricted
-on shared machines to prevent unauthorized access.
+A `clouds.yaml` file with the application credentials is also required. The credentials should not be unrestricted,
+as a compromised cluster would allow an attacker to create additional credentials.
+This file should be removed or restricted on shared machines to prevent unauthorized access.
 
 Preparing to Deploy
 ===================
@@ -32,8 +33,8 @@ Preparing to Deploy
 Background
 ----------
 
-A Kuberenetes cluster is required to create the cluster. To break this "chicken-egg" problem
-a Kuberenetes-in-Docker (KinD) cluster is created to bootstrap the main cluster. It is not
+A Kubernetes cluster is required to create the cluster. To break this "chicken-egg" problem
+a Kubernetes-in-Docker (KinD) cluster is created to bootstrap the main cluster. It is not
 recommended to use this cluster for any production workloads.
 
 Bootstrap Machine Prep
@@ -116,7 +117,8 @@ clouds.yaml Prep
         identity_api_version: 3
         auth_type: "v3applicationcredential"
 
-- Add the UUID of the project to create the cluster in. This can be found `here <https://openstack.stfc.ac.uk/identity/>`_.
+- Add the UUID of the project you want to create the cluster in. This is the project ID under the Openstack section which is omitted by default. 
+  This can be found `here <https://openstack.stfc.ac.uk/identity/>`_.
 
 Your clouds.yaml should now look like:
 
@@ -138,6 +140,23 @@ Your clouds.yaml should now look like:
 
 Creating the cluster
 ====================
+
+Yaml Files
+----------
+
+The configuration is spread across multiple yaml files to make it easier to manage.
+These are as follows:
+
+- `values.yaml` contains the default values for the cluster using the STFC Cloud service. These should not be changed.
+- `user-values.yaml` contains some values that must be set by the user. There are also optional values that can be changed too for advanced users.
+- `flavors.yaml` contains the Openstack flavors to use for worker nodes. Common flavors are provided and can be uncommented and changed as required.
+   By default the cluster will use l3.nano workers by default if unspecified.
+- `clouds.yaml` contains the Openstack application credentials. This file should be in the same directory as the other yaml files.
+
+The cloud team will periodically update `flavors.yaml`, `values.yaml`, and `user-values.yaml` to reflect changes in the STFC Cloud service.
+These include new versions of Kubernetes or machine images, best practices, new flavors...etc. A user will pull these changes 
+by running `git pull` in the scd-capi-values directory in the future.
+
 
 Configuring the cluster
 -----------------------

--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -240,7 +240,11 @@ minikube Shutdown
     kubectl get nodes
     
     # Update the cluster to ensure everything lines up with your helm chart
-    helm upgrade $CLUSTER_NAME capi/openstack-cluster --install -f values.yaml -f clouds.yaml -f user-values.yaml -f flavors.yaml
+    helm upgrade cluster-api-addon-provider capi-addons/cluster-api-addon-provider --install --version ">=0.1.0-dev.0.main.0,<0.1.0-dev.0.main.9999999999" --wait
+    helm upgrade $CLUSTER_NAME capi/openstack-cluster --install -f values.yaml -f clouds.yaml -f user-values.yaml -f flavors.yaml --wait
+
+    # Check the cluster status
+    clusterctl describe cluster $CLUSTER_NAME
 
 - Remove minikube bootstrap cluster
 

--- a/source/ClusterAPI/Setup.rst
+++ b/source/ClusterAPI/Setup.rst
@@ -23,7 +23,7 @@ to quickly gain access and perform recovery or upgrades as required.
 Account Security
 ----------------
 
-A `clouds.yaml` file with the application credentials is also required. The credentials should not be unrestricted,
+A ``clouds.yaml`` file with the application credentials is also required. The credentials should not be unrestricted,
 as a compromised cluster would allow an attacker to create additional credentials.
 This file should be removed or restricted on shared machines to prevent unauthorized access.
 
@@ -113,7 +113,7 @@ clouds.yaml Prep
 
 - Generate your application credentials: :ref:`Openstack Application Credentials<application_credentials>`. 
   It is recommended you use Horizon (the web interface) to download the clouds.yaml file.
-- Move your clouds.yaml file into the `scd-capi-values` directory, it should have the following format:
+- Move your clouds.yaml file into the ``scd-capi-values`` directory, it should have the following format:
 
 .. code-block:: yaml
 
@@ -158,24 +158,27 @@ Yaml Files
 The configuration is spread across multiple yaml files to make it easier to manage.
 These are as follows:
 
-- `values.yaml` contains the default values for the cluster using the STFC Cloud service. These should not be changed.
-- **`user-values.yaml` contains some values that must be set by the user.** There are also optional values that can be changed too for advanced users.
-- `flavors.yaml` contains the Openstack flavors to use for worker nodes. Common flavors are provided and can be uncommented and changed as required.
-   By default the cluster will use l3.nano workers by default if unspecified.
-- `clouds.yaml` contains the Openstack application credentials. This file should be in the same directory as the other yaml files.
+- ``values.yaml`` contains the default values for the cluster using the STFC Cloud service. These should not be changed.
 
-The cloud team will periodically update `flavors.yaml`, `values.yaml`, and `user-values.yaml` to reflect changes in the STFC Cloud service.
+-  ``user-values.yaml`` contains some values that must be set by the user. There are also optional values that can be changed too for advanced users.
+
+- ``flavors.yaml`` contains the Openstack flavors to use for worker nodes. Common flavors are provided and can be uncommented and changed as required. By default the cluster will use ``l3.nano`` workers by default if unspecified.
+
+- ``clouds.yaml`` contains the Openstack application credentials. This file should be in the same directory as the other yaml files.
+
+The cloud team will periodically update ``flavors.yaml``, ``values.yaml``, and ``user-values.yaml`` to reflect changes in the STFC Cloud service.
 These include new versions of Kubernetes or machine images, best practices, new flavors...etc. A user will pull these changes 
-by running `git pull` in the scd-capi-values directory in the future.
+by running ``git pull`` in the ``scd-capi-values`` directory in the future.
 
 
 Configuring the cluster
 -----------------------
 
-- The mandatory values in `user-values.yaml` must be set. Optional
+- The mandatory values in ``user-values.yaml`` must be set. Optional
   values may also be changed as required.
-- The `flavors.yaml` file contains the Openstack flavors to use for
-  worker nodes. These can be changed as required but will use l3.nano by default if unspecified.
+
+- The ``flavors.yaml`` file contains the Openstack flavors to use for worker nodes. 
+  These can be changed as required but will use ``l3.nano`` by default if unspecified.
 
 .. code-block:: bash
 

--- a/source/Keystone/ApplicationCredentials.rst
+++ b/source/Keystone/ApplicationCredentials.rst
@@ -1,3 +1,5 @@
+.. _application_credentials:
+
 =======================
 Application Credentials
 =======================


### PR DESCRIPTION
Replaces the old way of deploying with a new StackHPC deployment method that simplifies things from a user POV