### PR TITLE
Add warnings to aodh and gnocchi documentation

### DIFF
--- a/source/Aodh-and-Gnocchi/CreateAodhAlarms.rst
+++ b/source/Aodh-and-Gnocchi/CreateAodhAlarms.rst
@@ -2,7 +2,9 @@
 Create Aodh Alarms
 ==================
 
-This document is in progress.
+.. warning::
+
+  This component is currently disabled and not available.
 
 Aodh alarms can be created using the Openstack CLI or by using Aodh Resources in a heat template.
 

--- a/source/Aodh-and-Gnocchi/Gnocchi.rst
+++ b/source/Aodh-and-Gnocchi/Gnocchi.rst
@@ -2,6 +2,10 @@
 Gnocchi
 =========
 
+.. warning::
+
+  This component is currently disabled and not available.
+  
 Gnocchi processes data from Ceilometer and stores the processed data which can be accessed by users.
 It correlates measurements from Ceilometer to **resources** and **metrics**.
 

--- a/source/Aodh-and-Gnocchi/MonitoringVMsAodhGnocchi.rst
+++ b/source/Aodh-and-Gnocchi/MonitoringVMsAodhGnocchi.rst
@@ -1,6 +1,10 @@
 Monitoring Virtual Machines: Gnocchi and OpenStack Aodh
 #########################################################
 
+.. warning::
+
+  This component is currently disabled and not available.
+  
 This document is a brief introduction to Aodh and Gnocchi.
 
 We can monitor virtual machines by using alarms which fire when a threshold for a given measurement (e.g memory usage) has been met, when a VM has unexpectedly powered off, or when a VM has entered an error state.


### PR DESCRIPTION
Both these components are disabled and not available. A warning box has been added to the documentation for these two components. 