### PR TITLE
Update RunWebServerInDockerContainer.rst to use ubuntu and usergroups

### DIFF
--- a/source/howto/RunWebServerInDockerContainer.rst
+++ b/source/howto/RunWebServerInDockerContainer.rst
@@ -6,42 +6,78 @@ Running an NGinX webserver inside a Docker container
 
 This tutorial shows how to run a webserver with docker.
 
-Firstly create a VM - the instructions here are based on our ScientificLinux-7-NoGui image.
+Firstly create a VM - the instructions here are based on our ubuntu-focal-20.04-nogui image.
 
 SSH to your VM and install docker:
 
 .. code-block:: bash
 
-  sudo yum install docker-ce -y
+  # Add Docker's official GPG key:
+  sudo apt-get update
+  sudo apt-get install ca-certificates curl gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-Start and enable dockerd
+  # Add the repository to Apt sources:
+  echo \
+    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update
+
+Start and enable docker
 
 .. code-block:: bash
 
   sudo systemctl enable docker && sudo systemctl start docker
 
-Check that you are using our dockerhub mirror as described here: :ref:`check_docker_hub_mirror`.
+Add current user to the docker group **(Please do NOT run docker and containers as root)**
+
+.. code-block:: bash
+
+  sudo usermod -aG docker ${USER}
+
+Or if you need to add a user that is not logged in
+
+.. code-block:: bash
+
+  sudo usermod -aG docker username
+
+To apply new group you must logout and log back in 
+
+.. code-block:: bash
+
+  su - ${USER}
+
+You can confirm changes have applied by running
+
+.. code-block:: bash
+
+  groups
+  #Output:
+  wheel docker
 
 Pull the docker image for the nginx webserver
 
 .. code-block:: bash
 
-    sudo docker pull nginx
+    docker pull nginx
 
 Run the nginx docker container:
 
 .. code-block:: bash
 
-  sudo docker run -it --rm -d -p 80:80 --name nginx nginx
+  docker run -it --rm -d -p 80:80 --name nginx nginx
 
 Check that the container is running
 
 .. code-block:: bash
 
-  sudo docker ps
+  docker ps
 
 You should see the nginx container running
 
 You should now be able to browse to your webserver at the http://<instance-ip>
 
-If this doesnt work check the security group for your instance
+If this doesnt work check the security group for your instance, enabling http traffic through.

--- a/source/howto/RunWebServerInDockerContainer.rst
+++ b/source/howto/RunWebServerInDockerContainer.rst
@@ -36,7 +36,8 @@ To apply new group you must logout and log back in
 
 .. code-block:: bash
 
-  su - ${USER}
+  exit
+  ssh user@<your_ip>
 
 You can confirm changes have applied by running
 

--- a/source/howto/RunWebServerInDockerContainer.rst
+++ b/source/howto/RunWebServerInDockerContainer.rst
@@ -12,19 +12,7 @@ SSH to your VM and install docker:
 
 .. code-block:: bash
 
-  # Add Docker's official GPG key:
-  sudo apt-get update
-  sudo apt-get install ca-certificates curl gnupg
-  sudo install -m 0755 -d /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-  sudo chmod a+r /etc/apt/keyrings/docker.gpg
-
-  # Add the repository to Apt sources:
-  echo \
-    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-  sudo apt-get update
+  sudo apt-get update && sudo apt-get install docker.io
 
 Start and enable docker
 


### PR DESCRIPTION
Instructions were outdated and still based on SL7.

Related ticket: [CLDSCRM-535](https://stfc.atlassian.net/browse/CLDSCRM-535?atlOrigin=eyJpIjoiYTQ0NzczNmI1MTVhNGIyNGI4ODY0Y2Y0NzM0NjMyY2IiLCJwIjoiaiJ9)

Changes:
- [X] Updated to be based on Ubuntu focal 20.04, new install instructions for adding Docker apt repositories.
- [X] Advised to add users to Dock group, instead of running docker and containers as root
- [X] Put in a strongly worded message to deter users from using root